### PR TITLE
normalize unicode safely

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -7,14 +7,10 @@ import (
 	"time"
 )
 
-func IsNickname(nick string) bool {
-	return NicknameExpr.MatchString(nick)
-}
-
 type Client struct {
 	atime        time.Time
 	authorized   bool
-	awayMessage  string
+	awayMessage  Text
 	capabilities CapabilitySet
 	capState     CapState
 	channels     ChannelSet
@@ -23,16 +19,16 @@ type Client struct {
 	flags        map[UserMode]bool
 	hasQuit      bool
 	hops         uint
-	hostname     string
+	hostname     Name
 	idleTimer    *time.Timer
 	loginTimer   *time.Timer
-	nick         string
+	nick         Name
 	phase        Phase
 	quitTimer    *time.Timer
-	realname     string
+	realname     Text
 	server       *Server
 	socket       *Socket
-	username     string
+	username     Name
 }
 
 func NewClient(server *Server, conn net.Conn) *Client {
@@ -186,27 +182,27 @@ func (c *Client) ModeString() (str string) {
 	return
 }
 
-func (c *Client) UserHost() string {
+func (c *Client) UserHost() Name {
 	username := "*"
 	if c.HasUsername() {
-		username = c.username
+		username = c.username.String()
 	}
-	return fmt.Sprintf("%s!%s@%s", c.Nick(), username, c.hostname)
+	return Name(fmt.Sprintf("%s!%s@%s", c.Nick(), username, c.hostname))
 }
 
-func (c *Client) Nick() string {
+func (c *Client) Nick() Name {
 	if c.HasNick() {
 		return c.nick
 	}
-	return "*"
+	return Name("*")
 }
 
-func (c *Client) Id() string {
+func (c *Client) Id() Name {
 	return c.UserHost()
 }
 
 func (c *Client) String() string {
-	return c.Id()
+	return c.Id().String()
 }
 
 func (client *Client) Friends() ClientSet {
@@ -220,12 +216,12 @@ func (client *Client) Friends() ClientSet {
 	return friends
 }
 
-func (client *Client) SetNickname(nickname string) {
+func (client *Client) SetNickname(nickname Name) {
 	client.nick = nickname
 	client.server.clients.Add(client)
 }
 
-func (client *Client) ChangeNickname(nickname string) {
+func (client *Client) ChangeNickname(nickname Name) {
 	// Make reply before changing nick to capture original source id.
 	reply := RplNick(client, nickname)
 	client.server.clients.Remove(client)
@@ -244,7 +240,7 @@ func (client *Client) Reply(reply string, args ...interface{}) {
 	client.socket.Write(reply)
 }
 
-func (client *Client) Quit(message string) {
+func (client *Client) Quit(message Text) {
 	if client.hasQuit {
 		return
 	}

--- a/irc/config.go
+++ b/irc/config.go
@@ -37,10 +37,10 @@ type Config struct {
 	}
 }
 
-func (conf *Config) Operators() map[string][]byte {
-	operators := make(map[string][]byte)
+func (conf *Config) Operators() map[Name][]byte {
+	operators := make(map[Name][]byte)
 	for name, opConf := range conf.Operator {
-		operators[name] = opConf.PasswordBytes()
+		operators[NewName(name)] = opConf.PasswordBytes()
 	}
 	return operators
 }

--- a/irc/constants.go
+++ b/irc/constants.go
@@ -2,7 +2,6 @@ package irc
 
 import (
 	"errors"
-	"regexp"
 	"time"
 )
 
@@ -15,11 +14,6 @@ var (
 
 	// errors
 	ErrAlreadyDestroyed = errors.New("already destroyed")
-
-	// regexps
-	ChannelNameExpr = regexp.MustCompile(`^[&!#+][\pL\pN]{1,63}$`)
-	NicknameExpr    = regexp.MustCompile(
-		"^[\\pL\\pN\\pP\\pS]{1,32}$")
 )
 
 const (

--- a/irc/net.go
+++ b/irc/net.go
@@ -5,25 +5,25 @@ import (
 	"strings"
 )
 
-func IPString(addr net.Addr) string {
+func IPString(addr net.Addr) Name {
 	addrStr := addr.String()
 	ipaddr, _, err := net.SplitHostPort(addrStr)
 	if err != nil {
-		return addrStr
+		return Name(addrStr)
 	}
-	return ipaddr
+	return Name(ipaddr)
 }
 
-func AddrLookupHostname(addr net.Addr) string {
+func AddrLookupHostname(addr net.Addr) Name {
 	return LookupHostname(IPString(addr))
 }
 
-func LookupHostname(addr string) string {
-	names, err := net.LookupAddr(addr)
+func LookupHostname(addr Name) Name {
+	names, err := net.LookupAddr(addr.String())
 	if err != nil {
-		return addr
+		return Name(addr)
 	}
 
 	hostname := strings.TrimSuffix(names[0], ".")
-	return hostname
+	return Name(hostname)
 }

--- a/irc/reply.go
+++ b/irc/reply.go
@@ -79,23 +79,23 @@ func (target *Client) MultilineReply(names []string, code NumericCode, format st
 // messaging replies
 //
 
-func RplPrivMsg(source Identifier, target Identifier, message string) string {
+func RplPrivMsg(source Identifier, target Identifier, message Text) string {
 	return NewStringReply(source, PRIVMSG, "%s :%s", target.Nick(), message)
 }
 
-func RplNotice(source Identifier, target Identifier, message string) string {
+func RplNotice(source Identifier, target Identifier, message Text) string {
 	return NewStringReply(source, NOTICE, "%s :%s", target.Nick(), message)
 }
 
-func RplNick(source Identifier, newNick string) string {
-	return NewStringReply(source, NICK, newNick)
+func RplNick(source Identifier, newNick Name) string {
+	return NewStringReply(source, NICK, newNick.String())
 }
 
 func RplJoin(client *Client, channel *Channel) string {
-	return NewStringReply(client, JOIN, channel.name)
+	return NewStringReply(client, JOIN, channel.name.String())
 }
 
-func RplPart(client *Client, channel *Channel, message string) string {
+func RplPart(client *Client, channel *Channel, message Text) string {
 	return NewStringReply(client, PART, "%s :%s", channel, message)
 }
 
@@ -117,10 +117,10 @@ func RplPing(target Identifier) string {
 }
 
 func RplPong(client *Client) string {
-	return NewStringReply(nil, PONG, client.Nick())
+	return NewStringReply(nil, PONG, client.Nick().String())
 }
 
-func RplQuit(client *Client, message string) string {
+func RplQuit(client *Client, message Text) string {
 	return NewStringReply(client, QUIT, ":%s", message)
 }
 
@@ -128,16 +128,16 @@ func RplError(message string) string {
 	return NewStringReply(nil, ERROR, ":%s", message)
 }
 
-func RplInviteMsg(inviter *Client, invitee *Client, channel string) string {
+func RplInviteMsg(inviter *Client, invitee *Client, channel Name) string {
 	return NewStringReply(inviter, INVITE, "%s :%s", invitee.Nick(), channel)
 }
 
-func RplKick(channel *Channel, client *Client, target *Client, comment string) string {
+func RplKick(channel *Channel, client *Client, target *Client, comment Text) string {
 	return NewStringReply(client, KICK, "%s %s :%s",
 		channel, target.Nick(), comment)
 }
 
-func RplKill(client *Client, target *Client, comment string) string {
+func RplKill(client *Client, target *Client, comment Text) string {
 	return NewStringReply(client, KICK,
 		"%s :%s", target.Nick(), comment)
 }
@@ -184,7 +184,7 @@ func (target *Client) RplTopic(channel *Channel) {
 
 // <nick> <channel>
 // NB: correction in errata
-func (target *Client) RplInvitingMsg(invitee *Client, channel string) {
+func (target *Client) RplInvitingMsg(invitee *Client, channel Name) {
 	target.NumericReply(RPL_INVITING,
 		"%s %s", invitee.Nick(), channel)
 }
@@ -253,7 +253,7 @@ func (target *Client) RplWhoReply(channel *Channel, client *Client) {
 	}
 
 	if channel != nil {
-		channelName = channel.name
+		channelName = channel.name.String()
 		if target.capabilities[MultiPrefix] {
 			if channel.members[client][ChannelOperator] {
 				flags += "@"
@@ -275,12 +275,12 @@ func (target *Client) RplWhoReply(channel *Channel, client *Client) {
 }
 
 // <name> :End of WHO list
-func (target *Client) RplEndOfWho(name string) {
+func (target *Client) RplEndOfWho(name Name) {
 	target.NumericReply(RPL_ENDOFWHO,
 		"%s :End of WHO list", name)
 }
 
-func (target *Client) RplMaskList(mode ChannelMode, channel *Channel, mask string) {
+func (target *Client) RplMaskList(mode ChannelMode, channel *Channel, mask Name) {
 	switch mode {
 	case BanMask:
 		target.RplBanList(channel, mask)
@@ -306,7 +306,7 @@ func (target *Client) RplEndOfMaskList(mode ChannelMode, channel *Channel) {
 	}
 }
 
-func (target *Client) RplBanList(channel *Channel, mask string) {
+func (target *Client) RplBanList(channel *Channel, mask Name) {
 	target.NumericReply(RPL_BANLIST,
 		"%s %s", channel, mask)
 }
@@ -316,7 +316,7 @@ func (target *Client) RplEndOfBanList(channel *Channel) {
 		"%s :End of channel ban list", channel)
 }
 
-func (target *Client) RplExceptList(channel *Channel, mask string) {
+func (target *Client) RplExceptList(channel *Channel, mask Name) {
 	target.NumericReply(RPL_EXCEPTLIST,
 		"%s %s", channel, mask)
 }
@@ -326,7 +326,7 @@ func (target *Client) RplEndOfExceptList(channel *Channel) {
 		"%s :End of channel exception list", channel)
 }
 
-func (target *Client) RplInviteList(channel *Channel, mask string) {
+func (target *Client) RplInviteList(channel *Channel, mask Name) {
 	target.NumericReply(RPL_INVITELIST,
 		"%s %s", channel, mask)
 }
@@ -396,7 +396,7 @@ func (target *Client) RplVersion() {
 		"%s %s", SEM_VER, target.server.name)
 }
 
-func (target *Client) RplInviting(invitee *Client, channel string) {
+func (target *Client) RplInviting(invitee *Client, channel Name) {
 	target.NumericReply(RPL_INVITING,
 		"%s %s", invitee.Nick(), channel)
 }
@@ -412,7 +412,7 @@ func (target *Client) RplWhoWasUser(whoWas *WhoWas) {
 		whoWas.nickname, whoWas.username, whoWas.hostname, whoWas.realname)
 }
 
-func (target *Client) RplEndOfWhoWas(nickname string) {
+func (target *Client) RplEndOfWhoWas(nickname Name) {
 	target.NumericReply(RPL_ENDOFWHOWAS,
 		"%s :End of WHOWAS", nickname)
 }
@@ -426,7 +426,7 @@ func (target *Client) ErrAlreadyRegistered() {
 		":You may not reregister")
 }
 
-func (target *Client) ErrNickNameInUse(nick string) {
+func (target *Client) ErrNickNameInUse(nick Name) {
 	target.NumericReply(ERR_NICKNAMEINUSE,
 		"%s :Nickname is already in use", nick)
 }
@@ -441,12 +441,12 @@ func (target *Client) ErrUsersDontMatch() {
 		":Cannot change mode for other users")
 }
 
-func (target *Client) ErrNeedMoreParams(command string) {
+func (target *Client) ErrNeedMoreParams(command StringCode) {
 	target.NumericReply(ERR_NEEDMOREPARAMS,
 		"%s :Not enough parameters", command)
 }
 
-func (target *Client) ErrNoSuchChannel(channel string) {
+func (target *Client) ErrNoSuchChannel(channel Name) {
 	target.NumericReply(ERR_NOSUCHCHANNEL,
 		"%s :No such channel", channel)
 }
@@ -471,7 +471,7 @@ func (target *Client) ErrBadChannelKey(channel *Channel) {
 		"%s :Cannot join channel (+k)", channel.name)
 }
 
-func (target *Client) ErrNoSuchNick(nick string) {
+func (target *Client) ErrNoSuchNick(nick Name) {
 	target.NumericReply(ERR_NOSUCHNICK,
 		"%s :No such nick/channel", nick)
 }
@@ -493,7 +493,7 @@ func (target *Client) ErrRestricted() {
 	target.NumericReply(ERR_RESTRICTED, ":Your connection is restricted!")
 }
 
-func (target *Client) ErrNoSuchServer(server string) {
+func (target *Client) ErrNoSuchServer(server Name) {
 	target.NumericReply(ERR_NOSUCHSERVER, "%s :No such server", server)
 }
 
@@ -521,7 +521,7 @@ func (target *Client) ErrNoNicknameGiven() {
 	target.NumericReply(ERR_NONICKNAMEGIVEN, ":No nickname given")
 }
 
-func (target *Client) ErrErroneusNickname(nick string) {
+func (target *Client) ErrErroneusNickname(nick Name) {
 	target.NumericReply(ERR_ERRONEUSNICKNAME,
 		"%s :Erroneous nickname", nick)
 }
@@ -536,7 +536,7 @@ func (target *Client) ErrChannelIsFull(channel *Channel) {
 		"%s :Cannot join channel (+l)", channel)
 }
 
-func (target *Client) ErrWasNoSuchNick(nickname string) {
+func (target *Client) ErrWasNoSuchNick(nickname Name) {
 	target.NumericReply(ERR_WASNOSUCHNICK,
 		"%s :There was no such nickname", nickname)
 }

--- a/irc/server.go
+++ b/irc/server.go
@@ -24,9 +24,9 @@ type Server struct {
 	db        *sql.DB
 	idle      chan *Client
 	motdFile  string
-	name      string
+	name      Name
 	newConns  chan net.Conn
-	operators map[string][]byte
+	operators map[Name][]byte
 	password  []byte
 	signals   chan os.Signal
 	whoWas    *WhoWasList
@@ -41,7 +41,7 @@ func NewServer(config *Config) *Server {
 		db:        OpenDB(config.Server.Database),
 		idle:      make(chan *Client, 16),
 		motdFile:  config.Server.MOTD,
-		name:      config.Server.Name,
+		name:      NewName(config.Server.Name),
 		newConns:  make(chan net.Conn, 16),
 		operators: config.Operators(),
 		signals:   make(chan os.Signal, 1),
@@ -68,7 +68,7 @@ func loadChannelList(channel *Channel, list string, maskMode ChannelMode) {
 	if list == "" {
 		return
 	}
-	channel.lists[maskMode].AddAll(strings.Split(list, " "))
+	channel.lists[maskMode].AddAll(NewNames(strings.Split(list, " ")))
 }
 
 func (server *Server) loadChannels() {
@@ -80,7 +80,9 @@ func (server *Server) loadChannels() {
 		log.Fatal("error loading channels: ", err)
 	}
 	for rows.Next() {
-		var name, flags, key, topic string
+		var name Name
+		var flags string
+		var key, topic Text
 		var userLimit uint64
 		var banList, exceptList, inviteList string
 		err = rows.Scan(&name, &flags, &key, &topic, &userLimit, &banList,
@@ -248,15 +250,15 @@ func (server *Server) MOTD(client *Client) {
 	client.RplMOTDEnd()
 }
 
-func (s *Server) Id() string {
+func (s *Server) Id() Name {
 	return s.name
 }
 
 func (s *Server) String() string {
-	return s.name
+	return s.name.String()
 }
 
-func (s *Server) Nick() string {
+func (s *Server) Nick() Name {
 	return s.Id()
 }
 
@@ -339,7 +341,7 @@ func (m *NickCommand) HandleRegServer(s *Server) {
 		return
 	}
 
-	if !IsNickname(m.nickname) {
+	if !m.nickname.IsNickname() {
 		client.ErrErroneusNickname(m.nickname)
 		return
 	}
@@ -416,7 +418,7 @@ func (msg *NickCommand) HandleServer(server *Server) {
 		return
 	}
 
-	if !IsNickname(msg.nickname) {
+	if !msg.nickname.IsNickname() {
 		client.ErrErroneusNickname(msg.nickname)
 		return
 	}
@@ -447,13 +449,13 @@ func (m *JoinCommand) HandleServer(s *Server) {
 
 	if m.zero {
 		for channel := range client.channels {
-			channel.Part(client, client.Nick())
+			channel.Part(client, client.Nick().Text())
 		}
 		return
 	}
 
 	for name, key := range m.channels {
-		if !IsChannel(name) {
+		if !name.IsChannel() {
 			client.ErrNoSuchChannel(name)
 			continue
 		}
@@ -497,7 +499,7 @@ func (msg *TopicCommand) HandleServer(server *Server) {
 
 func (msg *PrivMsgCommand) HandleServer(server *Server) {
 	client := msg.Client()
-	if IsChannel(msg.target) {
+	if msg.target.IsChannel() {
 		channel := server.channels.Get(msg.target)
 		if channel == nil {
 			client.ErrNoSuchChannel(msg.target)
@@ -577,13 +579,13 @@ func (client *Client) WhoisChannelsNames() []string {
 	for channel := range client.channels {
 		switch {
 		case channel.members[client][ChannelOperator]:
-			chstrs[index] = "@" + channel.name
+			chstrs[index] = "@" + channel.name.String()
 
 		case channel.members[client][Voice]:
-			chstrs[index] = "+" + channel.name
+			chstrs[index] = "+" + channel.name.String()
 
 		default:
-			chstrs[index] = channel.name
+			chstrs[index] = channel.name.String()
 		}
 		index += 1
 	}
@@ -635,7 +637,7 @@ func (msg *WhoCommand) HandleServer(server *Server) {
 		for _, channel := range server.channels {
 			whoChannel(client, channel, friends)
 		}
-	} else if IsChannel(mask) {
+	} else if mask.IsChannel() {
 		// TODO implement wildcard matching
 		channel := server.channels.Get(mask)
 		if channel != nil {
@@ -685,7 +687,7 @@ func (msg *IsOnCommand) HandleServer(server *Server) {
 	ison := make([]string, 0)
 	for _, nick := range msg.nicks {
 		if iclient := server.clients.Get(nick); iclient != nil {
-			ison = append(ison, iclient.Nick())
+			ison = append(ison, iclient.Nick().String())
 		}
 	}
 
@@ -698,7 +700,7 @@ func (msg *MOTDCommand) HandleServer(server *Server) {
 
 func (msg *NoticeCommand) HandleServer(server *Server) {
 	client := msg.Client()
-	if IsChannel(msg.target) {
+	if msg.target.IsChannel() {
 		channel := server.channels.Get(msg.target)
 		if channel == nil {
 			client.ErrNoSuchChannel(msg.target)
@@ -785,7 +787,7 @@ func (msg *NamesCommand) HandleServer(server *Server) {
 }
 
 func (server *Server) Reply(target *Client, format string, args ...interface{}) {
-	target.Reply(RplPrivMsg(server, target, fmt.Sprintf(format, args...)))
+	target.Reply(RplPrivMsg(server, target, NewText(fmt.Sprintf(format, args...))))
 }
 
 func (msg *DebugCommand) HandleServer(server *Server) {
@@ -880,7 +882,7 @@ func (msg *KillCommand) HandleServer(server *Server) {
 	}
 
 	quitMsg := fmt.Sprintf("KILLed by %s: %s", client.Nick(), msg.comment)
-	target.Quit(quitMsg)
+	target.Quit(NewText(quitMsg))
 }
 
 func (msg *WhoWasCommand) HandleServer(server *Server) {

--- a/irc/strings.go
+++ b/irc/strings.go
@@ -1,0 +1,66 @@
+package irc
+
+import (
+	"code.google.com/p/go.text/unicode/norm"
+	"regexp"
+	"strings"
+)
+
+var (
+	// regexps
+	ChannelNameExpr = regexp.MustCompile(`^[&!#+][\pL\pN]{1,63}$`)
+	NicknameExpr    = regexp.MustCompile("^[\\pL\\pN\\pP\\pS]{1,32}$")
+)
+
+// Names are normalized and canonicalized to remove formatting marks
+// and simplify usage. They are things like hostnames and usermasks.
+type Name string
+
+func NewName(str string) Name {
+	return Name(norm.NFKC.String(str))
+}
+
+func NewNames(strs []string) []Name {
+	names := make([]Name, len(strs))
+	for index, str := range strs {
+		names[index] = NewName(str)
+	}
+	return names
+}
+
+// tests
+
+func (name Name) IsChannel() bool {
+	return ChannelNameExpr.MatchString(name.String())
+}
+
+func (name Name) IsNickname() bool {
+	return NicknameExpr.MatchString(name.String())
+}
+
+// conversions
+
+func (name Name) String() string {
+	return string(name)
+}
+
+func (name Name) ToLower() Name {
+	return Name(strings.ToLower(name.String()))
+}
+
+// It's safe to coerce a Name to Text. Name is a strict subset of Text.
+func (name Name) Text() Text {
+	return Text(name)
+}
+
+// Text is PRIVMSG, NOTICE, or TOPIC data. It's canonicalized UTF8
+// data to simplify but keeps all formatting.
+type Text string
+
+func NewText(str string) Text {
+	return Text(norm.NFC.String(str))
+}
+
+func (text Text) String() string {
+	return string(text)
+}

--- a/irc/types.go
+++ b/irc/types.go
@@ -67,7 +67,7 @@ type ReplyCode interface {
 	String() string
 }
 
-type StringCode string
+type StringCode Name
 
 func (code StringCode) String() string {
 	return string(code)
@@ -86,25 +86,25 @@ func (mode ChannelMode) String() string {
 	return string(mode)
 }
 
-type ChannelNameMap map[string]*Channel
+type ChannelNameMap map[Name]*Channel
 
-func (channels ChannelNameMap) Get(name string) *Channel {
-	return channels[strings.ToLower(name)]
+func (channels ChannelNameMap) Get(name Name) *Channel {
+	return channels[name.ToLower()]
 }
 
 func (channels ChannelNameMap) Add(channel *Channel) error {
-	if channels[channel.name] != nil {
+	if channels[channel.name.ToLower()] != nil {
 		return fmt.Errorf("%s: already set", channel.name)
 	}
-	channels[channel.name] = channel
+	channels[channel.name.ToLower()] = channel
 	return nil
 }
 
 func (channels ChannelNameMap) Remove(channel *Channel) error {
-	if channel != channels[channel.name] {
+	if channel != channels[channel.name.ToLower()] {
 		return fmt.Errorf("%s: mismatch", channel.name)
 	}
-	delete(channels, channel.name)
+	delete(channels, channel.name.ToLower())
 	return nil
 }
 
@@ -182,8 +182,8 @@ func (channels ChannelSet) First() *Channel {
 //
 
 type Identifier interface {
-	Id() string
-	Nick() string
+	Id() Name
+	Nick() Name
 }
 
 type Replier interface {

--- a/irc/whowas.go
+++ b/irc/whowas.go
@@ -7,10 +7,10 @@ type WhoWasList struct {
 }
 
 type WhoWas struct {
-	nickname string
-	username string
-	hostname string
-	realname string
+	nickname Name
+	username Name
+	hostname Name
+	realname Text
 }
 
 func NewWhoWasList(size uint) *WhoWasList {
@@ -32,7 +32,7 @@ func (list *WhoWasList) Append(client *Client) {
 	}
 }
 
-func (list *WhoWasList) Find(nickname string, limit int64) []*WhoWas {
+func (list *WhoWasList) Find(nickname Name, limit int64) []*WhoWas {
 	results := make([]*WhoWas, 0)
 	for whoWas := range list.Each() {
 		if nickname != whoWas.nickname {


### PR DESCRIPTION
Don't let the client specify where to use various normalization algorithms. Command structs should be typed to accept the appropriate string derivatives.
