### PR TITLE
fix mandatory argument handling

### DIFF
--- a/ergonomadic.go
+++ b/ergonomadic.go
@@ -64,7 +64,7 @@ func main() {
 		irc.UpgradeDB(config.Server.Database)
 		log.Println("database upgraded: ", config.Server.Database)
 
-	default:
+	case "run":
 		runFlags.Parse(flag.Args()[1:])
 		config := loadConfig(conf)
 		irc.Log.SetLevel(config.Server.Log)
@@ -72,5 +72,8 @@ func main() {
 		log.Println(irc.SEM_VER, "running")
 		defer log.Println(irc.SEM_VER, "exiting")
 		server.Run()
+
+	default:
+		usage()
 	}
 }


### PR DESCRIPTION
On `master`,

```
$ ./ergonomadic 
panic: runtime error: slice bounds out of range
```

```
$ ./ergonomadic asdfasf
2014/03/15 20:48:22 irc.example.com listening on localhost:6667
```

With this patch, both those invocations show `usage` instead.
